### PR TITLE
Add onboarding flow and profile form

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,27 +5,23 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { enableScreens } from 'react-native-screens';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import OnboardingStep1 from './src/screens/Onboarding/OnboardingStep1';
+import OnboardingStep2 from './src/screens/Onboarding/OnboardingStep2';
+import ProfileScreen from './src/screens/Profile/ProfileScreen';
+import { RootStackParamList, HomeTabsParamList } from './src/navigation/types';
 
 // ubrzanje
 enableScreens();
 
-const Stack = createNativeStackNavigator();
-const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator<HomeTabsParamList>();
 
 // 1. Welcome ekran
 function WelcomeScreen() {
   return (
     <View style={styles.center}>
       <Text style={styles.title}>Dobrodošao u CaliMaster!</Text>
-    </View>
-  );
-}
-
-// 2. Profile ekran (kasnije nadogradiš formom)
-function ProfileScreen() {
-  return (
-    <View style={styles.center}>
-      <Text style={styles.title}>Profil korisnika</Text>
     </View>
   );
 }
@@ -43,11 +39,17 @@ function HomeTabs() {
 // Glavni App
 export default function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="Root" component={HomeTabs} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Stack.Navigator
+          initialRouteName="OnboardingStep1"
+          screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="OnboardingStep1" component={OnboardingStep1} />
+          <Stack.Screen name="OnboardingStep2" component={OnboardingStep2} />
+          <Stack.Screen name="HomeTabs" component={HomeTabs} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 

--- a/__mocks__/PickerMock.js
+++ b/__mocks__/PickerMock.js
@@ -1,0 +1,8 @@
+const React = require('react');
+const { View, Text } = require('react-native');
+
+function Picker() {
+  return React.createElement(View, null, React.createElement(Text, null, 'Picker'));
+}
+Picker.Item = () => null;
+module.exports = { Picker };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
+  ],
+  moduleNameMapper: {
+    '^@react-native-picker/picker$': '<rootDir>/__mocks__/PickerMock.js',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-native": "0.80.0",
     "react-native-gesture-handler": "^2.26.0",
     "react-native-safe-area-context": "^5.4.1",
+    "@react-native-picker/picker": "^2.4.8",
     "react-native-screens": "^4.11.1"
   },
   "devDependencies": {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,10 @@
+export type RootStackParamList = {
+  OnboardingStep1: undefined;
+  OnboardingStep2: { answers: string[] };
+  HomeTabs: undefined;
+};
+
+export type HomeTabsParamList = {
+  Welcome: undefined;
+  Profile: undefined;
+};

--- a/src/screens/Onboarding/OnboardingStep1.tsx
+++ b/src/screens/Onboarding/OnboardingStep1.tsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react';
+import {View, Text, Button} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../../navigation/types';
+import styles from './styles';
+
+export type OnboardingStep1Props = NativeStackScreenProps<RootStackParamList, 'OnboardingStep1'>;
+
+const OnboardingStep1: React.FC<OnboardingStep1Props> = ({navigation}) => {
+  const [answers] = useState<string[]>([]);
+
+  const handleNext = () => {
+    navigation.navigate('OnboardingStep2', {answers: [...answers, 'step1']});
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Welcome to CaliMaster</Text>
+      <Text style={styles.text}>This short tutorial will guide you through the basics.</Text>
+      <Button title="Next" onPress={handleNext} />
+    </View>
+  );
+};
+
+export default OnboardingStep1;

--- a/src/screens/Onboarding/OnboardingStep2.tsx
+++ b/src/screens/Onboarding/OnboardingStep2.tsx
@@ -1,0 +1,27 @@
+import React, {useState} from 'react';
+import {View, Text, Button} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../../navigation/types';
+import styles from './styles';
+
+export type OnboardingStep2Props = NativeStackScreenProps<RootStackParamList, 'OnboardingStep2'>;
+
+const OnboardingStep2: React.FC<OnboardingStep2Props> = ({navigation, route}) => {
+  const {answers} = route.params;
+  const [stepAnswer] = useState('step2');
+
+  const finish = () => {
+    console.log([...answers, stepAnswer]);
+    navigation.reset({index: 0, routes: [{name: 'HomeTabs'}]});
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Almost Done!</Text>
+      <Text style={styles.text}>You're ready to start using the app.</Text>
+      <Button title="Finish" onPress={finish} />
+    </View>
+  );
+};
+
+export default OnboardingStep2;

--- a/src/screens/Onboarding/styles.ts
+++ b/src/screens/Onboarding/styles.ts
@@ -1,0 +1,20 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  text: {
+    fontSize: 16,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -1,0 +1,66 @@
+import React, {useState} from 'react';
+import {View, Text, TextInput, Button} from 'react-native';
+import {Picker} from '@react-native-picker/picker';
+import styles from './styles';
+
+const ProfileScreen: React.FC = () => {
+  const [age, setAge] = useState('');
+  const [gender, setGender] = useState('Male');
+  const [height, setHeight] = useState('');
+  const [weight, setWeight] = useState('');
+  const [fitnessLevel, setFitnessLevel] = useState('Beginner');
+  const [goal, setGoal] = useState('');
+
+  const save = () => {
+    console.log({age, gender, height, weight, fitnessLevel, goal});
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Your Profile</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Age"
+        keyboardType="number-pad"
+        value={age}
+        onChangeText={setAge}
+      />
+      <Picker selectedValue={gender} onValueChange={setGender} style={styles.input}>
+        <Picker.Item label="Male" value="Male" />
+        <Picker.Item label="Female" value="Female" />
+        <Picker.Item label="Other" value="Other" />
+      </Picker>
+      <TextInput
+        style={styles.input}
+        placeholder="Height (cm)"
+        keyboardType="number-pad"
+        value={height}
+        onChangeText={setHeight}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Weight (kg)"
+        keyboardType="number-pad"
+        value={weight}
+        onChangeText={setWeight}
+      />
+      <Picker
+        selectedValue={fitnessLevel}
+        onValueChange={setFitnessLevel}
+        style={styles.input}>
+        <Picker.Item label="Beginner" value="Beginner" />
+        <Picker.Item label="Intermediate" value="Intermediate" />
+        <Picker.Item label="Advanced" value="Advanced" />
+      </Picker>
+      <TextInput
+        style={styles.input}
+        placeholder="Training goal"
+        value={goal}
+        onChangeText={setGoal}
+      />
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+};
+
+export default ProfileScreen;

--- a/src/screens/Profile/styles.ts
+++ b/src/screens/Profile/styles.ts
@@ -1,0 +1,21 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginBottom: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- add onboarding step screens and styles
- build profile form screen
- introduce navigation type definitions
- wrap navigation container with safe area provider
- mock picker in Jest and adjust config
- update dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851eef571c8832abda5d281ac32e9a5