### PR TITLE
Add AsyncStorage persistence to profile screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,27 +5,23 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { enableScreens } from 'react-native-screens';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import OnboardingStep1 from './src/screens/Onboarding/OnboardingStep1';
+import OnboardingStep2 from './src/screens/Onboarding/OnboardingStep2';
+import ProfileScreen from './src/screens/Profile/ProfileScreen';
+import { RootStackParamList, HomeTabsParamList } from './src/navigation/types';
 
 // ubrzanje
 enableScreens();
 
-const Stack = createNativeStackNavigator();
-const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator<HomeTabsParamList>();
 
 // 1. Welcome ekran
 function WelcomeScreen() {
   return (
     <View style={styles.center}>
       <Text style={styles.title}>Dobrodošao u CaliMaster!</Text>
-    </View>
-  );
-}
-
-// 2. Profile ekran (kasnije nadogradiš formom)
-function ProfileScreen() {
-  return (
-    <View style={styles.center}>
-      <Text style={styles.title}>Profil korisnika</Text>
     </View>
   );
 }
@@ -43,11 +39,17 @@ function HomeTabs() {
 // Glavni App
 export default function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="Root" component={HomeTabs} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Stack.Navigator
+          initialRouteName="OnboardingStep1"
+          screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="OnboardingStep1" component={OnboardingStep1} />
+          <Stack.Screen name="OnboardingStep2" component={OnboardingStep2} />
+          <Stack.Screen name="HomeTabs" component={HomeTabs} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
   );
 }
 

--- a/__mocks__/AsyncStorageMock.js
+++ b/__mocks__/AsyncStorageMock.js
@@ -1,0 +1,5 @@
+export default {
+  setItem: jest.fn().mockResolvedValue(null),
+  getItem: jest.fn().mockResolvedValue(null),
+  removeItem: jest.fn().mockResolvedValue(null),
+};

--- a/__mocks__/PickerMock.js
+++ b/__mocks__/PickerMock.js
@@ -1,0 +1,8 @@
+const React = require('react');
+const { View, Text } = require('react-native');
+
+function Picker() {
+  return React.createElement(View, null, React.createElement(Text, null, 'Picker'));
+}
+Picker.Item = () => null;
+module.exports = { Picker };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,11 @@
 module.exports = {
   preset: 'react-native',
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|@react-navigation)/)',
+  ],
+  moduleNameMapper: {
+    '^@react-native-picker/picker$': '<rootDir>/__mocks__/PickerMock.js',
+    '^@react-native-async-storage/async-storage$':
+      '<rootDir>/__mocks__/AsyncStorageMock.js',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "react-native": "0.80.0",
     "react-native-gesture-handler": "^2.26.0",
     "react-native-safe-area-context": "^5.4.1",
+    "@react-native-picker/picker": "^2.4.8",
+    "@react-native-async-storage/async-storage": "^1.22.0",
     "react-native-screens": "^4.11.1"
   },
   "devDependencies": {

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,10 @@
+export type RootStackParamList = {
+  OnboardingStep1: undefined;
+  OnboardingStep2: { answers: string[] };
+  HomeTabs: undefined;
+};
+
+export type HomeTabsParamList = {
+  Welcome: undefined;
+  Profile: undefined;
+};

--- a/src/screens/Onboarding/OnboardingStep1.tsx
+++ b/src/screens/Onboarding/OnboardingStep1.tsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react';
+import {View, Text, Button} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../../navigation/types';
+import styles from './styles';
+
+export type OnboardingStep1Props = NativeStackScreenProps<RootStackParamList, 'OnboardingStep1'>;
+
+const OnboardingStep1: React.FC<OnboardingStep1Props> = ({navigation}) => {
+  const [answers] = useState<string[]>([]);
+
+  const handleNext = () => {
+    navigation.navigate('OnboardingStep2', {answers: [...answers, 'step1']});
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Welcome to CaliMaster</Text>
+      <Text style={styles.text}>This short tutorial will guide you through the basics.</Text>
+      <Button title="Next" onPress={handleNext} />
+    </View>
+  );
+};
+
+export default OnboardingStep1;

--- a/src/screens/Onboarding/OnboardingStep2.tsx
+++ b/src/screens/Onboarding/OnboardingStep2.tsx
@@ -1,0 +1,27 @@
+import React, {useState} from 'react';
+import {View, Text, Button} from 'react-native';
+import {NativeStackScreenProps} from '@react-navigation/native-stack';
+import {RootStackParamList} from '../../navigation/types';
+import styles from './styles';
+
+export type OnboardingStep2Props = NativeStackScreenProps<RootStackParamList, 'OnboardingStep2'>;
+
+const OnboardingStep2: React.FC<OnboardingStep2Props> = ({navigation, route}) => {
+  const {answers} = route.params;
+  const [stepAnswer] = useState('step2');
+
+  const finish = () => {
+    console.log([...answers, stepAnswer]);
+    navigation.reset({index: 0, routes: [{name: 'HomeTabs'}]});
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Almost Done!</Text>
+      <Text style={styles.text}>You're ready to start using the app.</Text>
+      <Button title="Finish" onPress={finish} />
+    </View>
+  );
+};
+
+export default OnboardingStep2;

--- a/src/screens/Onboarding/styles.ts
+++ b/src/screens/Onboarding/styles.ts
@@ -1,0 +1,20 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  text: {
+    fontSize: 16,
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+});

--- a/src/screens/Profile/ProfileScreen.tsx
+++ b/src/screens/Profile/ProfileScreen.tsx
@@ -1,0 +1,126 @@
+import React, {useEffect, useState} from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+import {Picker} from '@react-native-picker/picker';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import styles from './styles';
+
+interface ProfileData {
+  age: number;
+  gender: string;
+  height: number;
+  weight: number;
+  fitnessLevel: string;
+  goal: string;
+}
+
+const STORAGE_KEY = '@CaliMaster:profile';
+
+const ProfileScreen: React.FC = () => {
+  const [profile, setProfile] = useState<ProfileData>({
+    age: 0,
+    gender: 'Male',
+    height: 0,
+    weight: 0,
+    fitnessLevel: 'Beginner',
+    goal: '',
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const json = await AsyncStorage.getItem(STORAGE_KEY);
+        if (json) {
+          setProfile(JSON.parse(json));
+        }
+      } catch (e) {
+        console.error('Failed to load profile', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const save = async () => {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+      Alert.alert('Profile saved');
+    } catch (e) {
+      console.error('Failed to save profile', e);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Your Profile</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Age"
+        keyboardType="number-pad"
+        value={profile.age ? profile.age.toString() : ''}
+        onChangeText={text =>
+          setProfile({...profile, age: parseInt(text, 10) || 0})
+        }
+      />
+      <Picker
+        selectedValue={profile.gender}
+        onValueChange={gender => setProfile({...profile, gender})}
+        style={styles.input}>
+        <Picker.Item label="Male" value="Male" />
+        <Picker.Item label="Female" value="Female" />
+        <Picker.Item label="Other" value="Other" />
+      </Picker>
+      <TextInput
+        style={styles.input}
+        placeholder="Height (cm)"
+        keyboardType="number-pad"
+        value={profile.height ? profile.height.toString() : ''}
+        onChangeText={text =>
+          setProfile({...profile, height: parseInt(text, 10) || 0})
+        }
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Weight (kg)"
+        keyboardType="number-pad"
+        value={profile.weight ? profile.weight.toString() : ''}
+        onChangeText={text =>
+          setProfile({...profile, weight: parseInt(text, 10) || 0})
+        }
+      />
+      <Picker
+        selectedValue={profile.fitnessLevel}
+        onValueChange={level => setProfile({...profile, fitnessLevel: level})}
+        style={styles.input}>
+        <Picker.Item label="Beginner" value="Beginner" />
+        <Picker.Item label="Intermediate" value="Intermediate" />
+        <Picker.Item label="Advanced" value="Advanced" />
+      </Picker>
+      <TextInput
+        style={styles.input}
+        placeholder="Training goal"
+        value={profile.goal}
+        onChangeText={goal => setProfile({...profile, goal})}
+      />
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+};
+
+export default ProfileScreen;

--- a/src/screens/Profile/styles.ts
+++ b/src/screens/Profile/styles.ts
@@ -1,0 +1,26 @@
+import {StyleSheet} from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  heading: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginBottom: 12,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- persist profile data using AsyncStorage
- add loading state and manual mocks for AsyncStorage
- map AsyncStorage mock in Jest config
- include dependency in package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851eef571c8832abda5d281ac32e9a5